### PR TITLE
Updated Schedule component, so that the day alternates upon mouse-click.

### DIFF
--- a/src/components/sections/Schedule.js
+++ b/src/components/sections/Schedule.js
@@ -107,7 +107,9 @@ class Schedule extends React.PureComponent {
               </Tab>
             ))}
           </Tabs>
+
           <List>
+          <h2 style={{marginLeft: '0.2rem'}}>Day {activeDay}</h2>
             {SCHEDULE[activeDay - 1].value.map(({ time, label }) => (
               <Item key={time}>
                 <Time>{time}</Time>


### PR DESCRIPTION
I updated the Schedule component, so that the day alternates upon mouse-click of one of the tabs. For example if the user clicks on the Day 1 tab, the header underneath will update to say Day 1, and so forth. The GIF below also illustrates this. 

![Schedule_DevFolioGatsbyStarter](https://user-images.githubusercontent.com/32362757/66258103-26e40100-e799-11e9-9815-e40214a0b8f5.gif)
