### PR TITLE
Fixes button overflow issue in schedule section for mobile screens

### DIFF
--- a/src/components/sections/Schedule.js
+++ b/src/components/sections/Schedule.js
@@ -126,6 +126,11 @@ const Tabs = styled.div`
   grid-template-columns: ${props => `repeat(${props.num}, 200px)`};
   grid-gap: 32px;
   justify-content: center;
+  @media (max-width: ${props => props.theme.screen.sm}) {
+    grid-template-columns: 100%;
+    grid-template-rows: auto;
+    grid-gap: 1em;
+  }
 `;
 
 const Tab = styled(Button)`


### PR DESCRIPTION
<!--
Remove the fields that are not appropriate
Please include:
-->

- **What does this PR do?**
Fixes #46 
- **Any background context you want to provide?**
  Added grid template behaviour for smaller screens.
- **Screenshots and/or Live Demo**
  Browser - Firefox 69.0
  ![Peek 2019-10-17 17-57](https://user-images.githubusercontent.com/20622980/67008704-b37eaf80-f107-11e9-9f95-32918886d1da.gif)
