### PR TITLE
feat(website): add current year in footer copywrite text

### DIFF
--- a/src/components/sections/Footer.js
+++ b/src/components/sections/Footer.js
@@ -35,7 +35,7 @@ const Footer = () => (
         alignItems: 'center',
       }}
     >
-      <Copyright>© Devfolio</Copyright>
+      <Copyright>Devfolio © {new Date().getFullYear()}</Copyright>
       <SocialIcons>
         {SOCIAL.map(({ icon: Icon, label, link }) => (
           <ExternalLink href={link} key={link} aria-label={label}><Icon aria-hidden={true} /></ExternalLink>


### PR DESCRIPTION
### Change:
- [x] Update footer Copywrite text to `Devfolio © 2020` - here, the current year will get displayed.

> This makes it look a lot better. Open to know your thoughts on this. Thanks