### PR TITLE
auto-fill schedule switch btn by width of 200px in grid below 767px.

### DIFF
--- a/src/components/sections/Schedule.js
+++ b/src/components/sections/Schedule.js
@@ -109,7 +109,7 @@ class Schedule extends React.PureComponent {
           </Tabs>
 
           <List>
-          <h2 style={{marginLeft: '0.2rem'}}>Day {activeDay}</h2>
+            <h2 style={{ marginLeft: '0.2rem' }}>Day {activeDay}</h2>
             {SCHEDULE[activeDay - 1].value.map(({ time, label }) => (
               <Item key={time}>
                 <Time>{time}</Time>
@@ -129,8 +129,8 @@ const Tabs = styled.div`
   grid-gap: 32px;
   justify-content: center;
   @media (max-width: ${props => props.theme.screen.sm}) {
-    grid-template-columns: 100%;
     grid-template-rows: auto;
+    grid-template-columns: repeat(auto-fill, 200px);
     grid-gap: 1em;
   }
 `;


### PR DESCRIPTION
currently schedule switch btn is taking 100% width below 767px, which is not looking good and not user friendly. 
**Before fix**:-
![Screenshot from 2020-10-03 14-29-32](https://user-images.githubusercontent.com/45959932/94987849-ee7f2a80-0586-11eb-871b-afd4ac8d08b2.png)
**After Fix**:-
![Screenshot from 2020-10-03 14-30-03](https://user-images.githubusercontent.com/45959932/94987859-f939bf80-0586-11eb-8fe0-fe1fc041c195.png)
